### PR TITLE
Correcting Overflow & Adding Missed 1M to The Sum

### DIFF
--- a/src/main/scala/part1recap/ThreadModelLimitations.scala
+++ b/src/main/scala/part1recap/ThreadModelLimitations.scala
@@ -87,12 +87,12 @@ object ThreadModelLimitations extends App {
   import scala.concurrent.ExecutionContext.Implicits.global
 
   val futures = (0 to 9)
-    .map(i => 100000 * i until 100000 * (i + 1)) // 0 - 99999, 100000 - 199999, 200000 - 299999 etc
+    .map(i => BigInt(100000) * i until BigInt(100000) * (i + 1)) // 0 - 99999, 100000 - 199999, 200000 - 299999 etc
     .map(range => Future {
       if (range.contains(546735)) throw new RuntimeException("invalid number")
       range.sum
     })
 
-  val sumFuture = Future.reduceLeft(futures)(_ + _) // Future with the sum of all the numbers
+  val sumFuture = Future.foldLeft(futures)(BigInt(1000000))(_ + _) // Future with the sum of all the numbers
   sumFuture.onComplete(println)
 }


### PR DESCRIPTION
having commented the exception the result produced by master code is **1783293664**
![image](https://user-images.githubusercontent.com/26833375/104095994-bc831000-52bb-11eb-8829-dbc43cf02703.png)

Correct result should be **500000500000**, [see](https://www.wolframalpha.com/input/?i=sum%281+to+1000000%29)
![image](https://user-images.githubusercontent.com/26833375/104096054-0cfa6d80-52bc-11eb-8ba9-53d851860e16.png)

Overflow happens due to log2(sum(1 to 1000000)) = **38.9** (approx) > 32 bit in integer. [see](https://www.wolframalpha.com/input/?i=log2%28sum%281+to+1000000%29%29).
![image](https://user-images.githubusercontent.com/26833375/104096091-36b39480-52bc-11eb-913f-2dbc8ea47c55.png)
